### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/pycocoevalcap/eval.py
+++ b/pycocoevalcap/eval.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'tylin'
 from tokenizer.ptbtokenizer import PTBTokenizer
 from bleu.bleu import Bleu
@@ -26,7 +27,7 @@ class COCOEvalCap:
         # =================================================
         # Set up scorers
         # =================================================
-        print 'tokenization...'
+        print('tokenization...')
         tokenizer = PTBTokenizer()
         gts  = tokenizer.tokenize(gts)
         res = tokenizer.tokenize(res)
@@ -34,7 +35,7 @@ class COCOEvalCap:
         # =================================================
         # Set up scorers
         # =================================================
-        print 'setting up scorers...'
+        print('setting up scorers...')
         scorers = [
             (Bleu(4), ["Bleu_1", "Bleu_2", "Bleu_3", "Bleu_4"]),
             (Meteor(),"METEOR"),
@@ -46,17 +47,17 @@ class COCOEvalCap:
         # Compute scores
         # =================================================
         for scorer, method in scorers:
-            print 'computing %s score...'%(scorer.method())
+            print('computing %s score...'%(scorer.method()))
             score, scores = scorer.compute_score(gts, res)
             if type(method) == list:
                 for sc, scs, m in zip(score, scores, method):
                     self.setEval(sc, m)
                     self.setImgToEvalImgs(scs, gts.keys(), m)
-                    print "%s: %0.3f"%(m, sc)
+                    print("%s: %0.3f"%(m, sc))
             else:
                 self.setEval(score, method)
                 self.setImgToEvalImgs(scores, gts.keys(), method)
-                print "%s: %0.3f"%(method, score)
+                print("%s: %0.3f"%(method, score))
         self.setEvalImgs()
 
     def setEval(self, score, method):


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.