### PR TITLE
Change line 51 to more accurately reflect Nvidia terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We created a demo script `demo.py` to ease the difficulty of the deployment of t
 
 #### Train model with Conda Environment
 
-Please use the below commandlines to clone, install the requirements and load the Conda environment (Note that Cuda 10 is required):
+Please use the below commandlines to clone, install the requirements and load the Conda environment (Note that the Nvidia CUDA 10.0 developer toolkit is required):
 
 
 ```bash


### PR DESCRIPTION
CUDA v10 does not exist, but the CUDA Toolkit v. 10.0 does. The CUDA engine shouldn't be confused with the CUDA toolkit.
Perhaps this should instead by CUDA Toolkit v.8.1, since that is the lowest version of the CUDA toolkit supported by Anaconda...